### PR TITLE
Crashfix for hsl dump when there are empty config files

### DIFF
--- a/halonctl/modules/hsl.py
+++ b/halonctl/modules/hsl.py
@@ -160,7 +160,7 @@ class ScriptFile(BaseFile):
 				else:
 					body += u'//= {0}\n'.format(block)
 		except AttributeError as e:
-			print('Error: empty config found, {}'.format(e))
+			print('Warning: empty config found, {}'.format(e))
 			pass
 		return body
 

--- a/halonctl/modules/hsl.py
+++ b/halonctl/modules/hsl.py
@@ -30,37 +30,37 @@ t = Terminal()
 class BaseFile(object):
 	filename = u'unnamed'
 	extension = u'bin'
-
+	
 	name = None
 	meta = None
 	body = u''
-
+	
 	@property
 	def full_filename(self):
 		return u"{0}.{1}".format(self.filename, self.extension)
-
-
-
+	
+	
+	
 	@classmethod
 	def from_file(class_, path):
 		f = class_()
 		f.load(path)
 		return f
-
-
-
+	
+	
+	
 	def __init__(self, item=None):
 		if item:
 			self.load_data(item)
-
+	
 	def load_data(self, item):
 		'''Loads data from a configKeys() SOAP payload.'''
 		pass
-
+	
 	def to_data(self):
 		'''Returns a dictionary of key:value pairs for configKeySet().'''
 		pass
-
+	
 	def deserialize(self, data):
 		'''Deserializes data read from a file.'''
 		lines = data.split('\n')
@@ -69,7 +69,7 @@ class BaseFile(object):
 		if lines[0].startswith('//= META: '):
 			self.meta = lines.pop(0)[10:]
 		self.body = u'\n'.join(lines)
-
+	
 	def serialize(self, node=None):
 		'''Serializes data for writing to a file.'''
 		data = u""
@@ -79,47 +79,47 @@ class BaseFile(object):
 			data += u"//= META: {0}\n".format(self.meta)
 		data += self.render(node)
 		return data
-
+	
 	def path(self, args):
 		'''Constructs a local path to the file.'''
 		return os.path.join(args.path, self.full_filename)
-
+	
 	def save(self, args):
 		#Avoid saving empty files
 		if not self.body:
 			return None
-
+		
 		if not os.path.exists(args.path):
 			os.makedirs(args.path)
-
+		
 		with open(self.path(args), 'w') as f:
 			f.write(self.serialize())
-
+	
 	def load(self, path):
 		with open(path) as f:
 			pts = os.path.splitext(os.path.basename(path))
 			self.filename, self.extension = pts[0], pts[1][1:]
 			self.deserialize(f.read())
-
+	
 	def diff(self, other, from_='', to='', node=None):
 		if self.serialize(node) == other.serialize(node):
 			return []
-
+		
 		return difflib.unified_diff(
 			self.serialize().split('\n'),
 			other.serialize().split('\n'),
 			from_, to, lineterm=''
 		)
-
+	
 	def render(self, node=None):
 		if not node:
 			return self.body
-
+		
 		return Template(self.body).render(node=node)
 
 class ScriptFile(BaseFile):
 	extension = 'hsl'
-
+	
 	def load_data(self, item):
 		self.filename = item.name
 		self.name = item.params.item[0]
@@ -129,20 +129,20 @@ class ScriptFile(BaseFile):
 			#Any empty scriptfile will cause an Attributerror
 			print(u"Notice: empty config \"{0}\" found".format(item.name), file=sys.stderr)
 			self.body = None
-
+		
 		# Some kinds of scripts (ACL Flows) have an extra middle parameter...
 		if len(item.params.item) > 2:
 			self.meta = item.params.item[1]
-
+	
 	def to_data(self, node=None):
 		def encode_script(lines):
 			txt = u'\n'.join(lines)
 			return u'script "{0}"'.format(to_base64(txt))
-
+		
 		items = { 'name': self.name }
 		if self.meta:
 			items['rate'] = self.meta
-
+		
 		body = self.render(node)
 		blocks = []
 		current_script = []
@@ -157,9 +157,9 @@ class ScriptFile(BaseFile):
 		if current_script:
 			blocks.append(encode_script(current_script))
 		items['flow'] = u','.join(blocks)
-
+		
 		return items
-
+	
 	def decode(self, data):
 		body = ''
 		for block in data.split(','):
@@ -171,11 +171,11 @@ class ScriptFile(BaseFile):
 
 class FragmentFile(BaseFile):
 	extension = 'hsl'
-
+	
 	def load_data(self, item):
 		self.filename = item.name
 		self.body = from_base64(item.params.item[0])
-
+	
 	def to_data(self, node=None):
 		return {
 			'value': to_base64(self.render(node))
@@ -183,19 +183,19 @@ class FragmentFile(BaseFile):
 
 class TextFile(BaseFile):
 	extension = 'txt'
-
+	
 	def load_data(self, item):
 		self.filename = item.name
 		self.extension = MIMES.get(item.params.item[1], 'bin')
 		self.name = item.params.item[0]
 		self.body = from_base64(item.params.item[2])
-
+	
 	def to_data(self, node=None):
 		mime = 'text/plain'
 		for t, ext in six.iteritems(MIMES):
 			if ext == self.extension:
 				mime = t
-
+		
 		return {
 			'name': self.name,
 			'type': mime,
@@ -264,42 +264,42 @@ def confirm_diff(diff, args):
 
 class HSLDumpModule(Module):
 	'''Dumps scripts from a node'''
-
+	
 	def register_arguments(self, parser):
 		parser.add_argument('path', nargs='?', default='.',
 			help=u"node configuration directory")
-
+	
 	def run(self, nodes, args):
 		# It doesn't make sense to dump from multiple nodes into one directory
 		node = nodes[0]
 		code, result = node.service.configKeys()
 		ignore = load_ignore_list(args.path)
-
+		
 		if code != 200:
 			self.exitcode = 1
 			return HTTPStatus(code)
-
+		
 		for f in files_from_result(result, ignore):
 			f.save(args)
 
 class HSLDiffModule(Module):
 	'''Views differences between local and remote files.'''
-
+	
 	def register_arguments(self, parser):
 		parser.add_argument('path', nargs='?', default='.',
 			help=u"node configuration directory")
-
+	
 	def run(self, nodes, args):
 		ignore = load_ignore_list(args.path)
 		local = { f.full_filename: f for f in files_from_storage(args.path, ignore) }
-
+		
 		diffs = {}
 		for node, (code, result) in six.iteritems(nodes.service.configKeys()):
 			if code != 200:
 				print(u"{0}: {1}".format(node, HTTPStatus(code).human()))
 				self.partial = True
 				continue
-
+			
 			for f in files_from_result(result, ignore):
 				f2 = local.get(f.full_filename, BaseFile())
 				diff = list(f.diff(f2, node.name, f.full_filename))
@@ -308,23 +308,23 @@ class HSLDiffModule(Module):
 
 class HSLPullModule(Module):
 	'''Merges remote changes into local files.'''
-
+	
 	def register_arguments(self, parser):
 		parser.add_argument('path', nargs='?', default='.',
 			help=u"node configuration directory")
 		parser.add_argument('-f', '--force', action='store_true',
 			help=u"apply changes without confirmation")
-
+	
 	def run(self, nodes, args):
 		ignore = load_ignore_list(args.path)
 		local = { f.full_filename: f for f in files_from_storage(args.path, ignore) }
-
+		
 		for node, (code, result) in six.iteritems(nodes.service.configKeys()):
 			if code != 200:
 				print(u"{0}: {1}".format(node, HTTPStatus(code).human()))
 				self.partial = True
 				continue
-
+			
 			for f in files_from_result(result, ignore):
 				f2 = local.get(f.full_filename, BaseFile())
 				diff = list(f2.diff(f, f.full_filename, node.name, node=node))
@@ -340,46 +340,46 @@ class HSLPullModule(Module):
 
 class HSLPushModule(Module):
 	'''Pushes local scripts to nodes.'''
-
+	
 	def register_arguments(self, parser):
 		parser.add_argument('path', nargs='?', default='.',
 			help=u"node configuration directory")
 		parser.add_argument('-f', '--force', action='store_true',
 			help=u"allow application of changes to all nodes")
-
+	
 	def run(self, nodes, args):
 		if len(nodes) == len(config['nodes']) and not args.force:
 			if not ask_confirm(dedent(u'''
 				{b}Warning:{n}
-
+				
 				Looks like you're about to push a configuration change to {b}all{n} of your
 				nodes! If any of them are clustered, this is probably not what you want.
-
+				
 				If the configuration change is written to multiple nodes in a cluster, each node
 				will push it out to its entire cluster, one after another, and each push will
 				cause every node in the cluster to recompile its configuration. If you're
 				pushing to an entire large cluster, this can cause excessive amounts of system
 				load across it!
-
+				
 				To silence this warning in the future, use the {b}-f{n} ({b}--force{n}) flag.
-
+				
 				Do you want to proceed?
 				'''.format(b=t.bold, n=t.normal)).strip(), default=False):
 				return
-
+		
 		ignore = load_ignore_list(args.path)
 		local = { f.full_filename: f for f in files_from_storage(args.path, ignore) }
-
+		
 		for node, (code, result) in six.iteritems(nodes.service.configKeys()):
 			if code != 200:
 				print(u"{0}: {1}".format(node, HTTPStatus(code).human()))
 				self.partial = True
 				continue
-
+			
 			for f in files_from_result(result, ignore):
 				if not f.full_filename in local:
 					continue
-
+				
 				f2 = local[f.full_filename]
 				diff = list(f.diff(f2, node.name, f2.full_filename, node=node))
 				if diff:
@@ -401,7 +401,7 @@ class HSLPushModule(Module):
 
 class HSLModule(Module):
 	'''Manages HSL scripts'''
-
+	
 	submodules = {
 		'dump': HSLDumpModule(),
 		'diff': HSLDiffModule(),

--- a/halonctl/modules/hsl.py
+++ b/halonctl/modules/hsl.py
@@ -30,37 +30,37 @@ t = Terminal()
 class BaseFile(object):
 	filename = u'unnamed'
 	extension = u'bin'
-	
+
 	name = None
 	meta = None
 	body = u''
-	
+
 	@property
 	def full_filename(self):
 		return u"{0}.{1}".format(self.filename, self.extension)
-	
-	
-	
+
+
+
 	@classmethod
 	def from_file(class_, path):
 		f = class_()
 		f.load(path)
 		return f
-	
-	
-	
+
+
+
 	def __init__(self, item=None):
 		if item:
 			self.load_data(item)
-	
+
 	def load_data(self, item):
 		'''Loads data from a configKeys() SOAP payload.'''
 		pass
-	
+
 	def to_data(self):
 		'''Returns a dictionary of key:value pairs for configKeySet().'''
 		pass
-	
+
 	def deserialize(self, data):
 		'''Deserializes data read from a file.'''
 		lines = data.split('\n')
@@ -69,7 +69,7 @@ class BaseFile(object):
 		if lines[0].startswith('//= META: '):
 			self.meta = lines.pop(0)[10:]
 		self.body = u'\n'.join(lines)
-	
+
 	def serialize(self, node=None):
 		'''Serializes data for writing to a file.'''
 		data = u""
@@ -79,61 +79,61 @@ class BaseFile(object):
 			data += u"//= META: {0}\n".format(self.meta)
 		data += self.render(node)
 		return data
-	
+
 	def path(self, args):
 		'''Constructs a local path to the file.'''
 		return os.path.join(args.path, self.full_filename)
-	
+
 	def save(self, args):
 		if not os.path.exists(args.path):
 			os.makedirs(args.path)
-		
+
 		with open(self.path(args), 'w') as f:
 			f.write(self.serialize())
-	
+
 	def load(self, path):
 		with open(path) as f:
 			pts = os.path.splitext(os.path.basename(path))
 			self.filename, self.extension = pts[0], pts[1][1:]
 			self.deserialize(f.read())
-	
+
 	def diff(self, other, from_='', to='', node=None):
 		if self.serialize(node) == other.serialize(node):
 			return []
-		
+
 		return difflib.unified_diff(
 			self.serialize().split('\n'),
 			other.serialize().split('\n'),
 			from_, to, lineterm=''
 		)
-	
+
 	def render(self, node=None):
 		if not node:
 			return self.body
-		
+
 		return Template(self.body).render(node=node)
 
 class ScriptFile(BaseFile):
 	extension = 'hsl'
-	
+
 	def load_data(self, item):
 		self.filename = item.name
 		self.name = item.params.item[0]
 		self.body = self.decode(item.params.item[-1])
-		
+
 		# Some kinds of scripts (ACL Flows) have an extra middle parameter...
 		if len(item.params.item) > 2:
 			self.meta = item.params.item[1]
-	
+
 	def to_data(self, node=None):
 		def encode_script(lines):
 			txt = u'\n'.join(lines)
 			return u'script "{0}"'.format(to_base64(txt))
-		
+
 		items = { 'name': self.name }
 		if self.meta:
 			items['rate'] = self.meta
-		
+
 		body = self.render(node)
 		blocks = []
 		current_script = []
@@ -148,25 +148,29 @@ class ScriptFile(BaseFile):
 		if current_script:
 			blocks.append(encode_script(current_script))
 		items['flow'] = u','.join(blocks)
-		
+
 		return items
-	
+
 	def decode(self, data):
 		body = ''
-		for block in data.split(','):
-			if block.startswith('script '):
-				body += u'{0}\n'.format(from_base64(block[8:-1]))
-			else:
-				body += u'//= {0}\n'.format(block)
+		try:
+			for block in data.split(','):
+				if block.startswith('script '):
+					body += u'{0}\n'.format(from_base64(block[8:-1]))
+				else:
+					body += u'//= {0}\n'.format(block)
+		except AttributeError as e:
+			print('Error: empty config found, {}'.format(e))
+			pass
 		return body
 
 class FragmentFile(BaseFile):
 	extension = 'hsl'
-	
+
 	def load_data(self, item):
 		self.filename = item.name
 		self.body = from_base64(item.params.item[0])
-	
+
 	def to_data(self, node=None):
 		return {
 			'value': to_base64(self.render(node))
@@ -174,19 +178,19 @@ class FragmentFile(BaseFile):
 
 class TextFile(BaseFile):
 	extension = 'txt'
-	
+
 	def load_data(self, item):
 		self.filename = item.name
 		self.extension = MIMES.get(item.params.item[1], 'bin')
 		self.name = item.params.item[0]
 		self.body = from_base64(item.params.item[2])
-	
+
 	def to_data(self, node=None):
 		mime = 'text/plain'
 		for t, ext in six.iteritems(MIMES):
 			if ext == self.extension:
 				mime = t
-		
+
 		return {
 			'name': self.name,
 			'type': mime,
@@ -255,42 +259,42 @@ def confirm_diff(diff, args):
 
 class HSLDumpModule(Module):
 	'''Dumps scripts from a node'''
-	
+
 	def register_arguments(self, parser):
 		parser.add_argument('path', nargs='?', default='.',
 			help=u"node configuration directory")
-	
+
 	def run(self, nodes, args):
 		# It doesn't make sense to dump from multiple nodes into one directory
 		node = nodes[0]
 		code, result = node.service.configKeys()
 		ignore = load_ignore_list(args.path)
-		
+
 		if code != 200:
 			self.exitcode = 1
 			return HTTPStatus(code)
-		
+
 		for f in files_from_result(result, ignore):
 			f.save(args)
 
 class HSLDiffModule(Module):
 	'''Views differences between local and remote files.'''
-	
+
 	def register_arguments(self, parser):
 		parser.add_argument('path', nargs='?', default='.',
 			help=u"node configuration directory")
-	
+
 	def run(self, nodes, args):
 		ignore = load_ignore_list(args.path)
 		local = { f.full_filename: f for f in files_from_storage(args.path, ignore) }
-		
+
 		diffs = {}
 		for node, (code, result) in six.iteritems(nodes.service.configKeys()):
 			if code != 200:
 				print(u"{0}: {1}".format(node, HTTPStatus(code).human()))
 				self.partial = True
 				continue
-			
+
 			for f in files_from_result(result, ignore):
 				f2 = local.get(f.full_filename, BaseFile())
 				diff = list(f.diff(f2, node.name, f.full_filename))
@@ -299,23 +303,23 @@ class HSLDiffModule(Module):
 
 class HSLPullModule(Module):
 	'''Merges remote changes into local files.'''
-	
+
 	def register_arguments(self, parser):
 		parser.add_argument('path', nargs='?', default='.',
 			help=u"node configuration directory")
 		parser.add_argument('-f', '--force', action='store_true',
 			help=u"apply changes without confirmation")
-	
+
 	def run(self, nodes, args):
 		ignore = load_ignore_list(args.path)
 		local = { f.full_filename: f for f in files_from_storage(args.path, ignore) }
-		
+
 		for node, (code, result) in six.iteritems(nodes.service.configKeys()):
 			if code != 200:
 				print(u"{0}: {1}".format(node, HTTPStatus(code).human()))
 				self.partial = True
 				continue
-			
+
 			for f in files_from_result(result, ignore):
 				f2 = local.get(f.full_filename, BaseFile())
 				diff = list(f2.diff(f, f.full_filename, node.name, node=node))
@@ -331,46 +335,46 @@ class HSLPullModule(Module):
 
 class HSLPushModule(Module):
 	'''Pushes local scripts to nodes.'''
-	
+
 	def register_arguments(self, parser):
 		parser.add_argument('path', nargs='?', default='.',
 			help=u"node configuration directory")
 		parser.add_argument('-f', '--force', action='store_true',
 			help=u"allow application of changes to all nodes")
-	
+
 	def run(self, nodes, args):
 		if len(nodes) == len(config['nodes']) and not args.force:
 			if not ask_confirm(dedent(u'''
 				{b}Warning:{n}
-				
+
 				Looks like you're about to push a configuration change to {b}all{n} of your
 				nodes! If any of them are clustered, this is probably not what you want.
-				
+
 				If the configuration change is written to multiple nodes in a cluster, each node
 				will push it out to its entire cluster, one after another, and each push will
 				cause every node in the cluster to recompile its configuration. If you're
 				pushing to an entire large cluster, this can cause excessive amounts of system
 				load across it!
-				
+
 				To silence this warning in the future, use the {b}-f{n} ({b}--force{n}) flag.
-				
+
 				Do you want to proceed?
 				'''.format(b=t.bold, n=t.normal)).strip(), default=False):
 				return
-		
+
 		ignore = load_ignore_list(args.path)
 		local = { f.full_filename: f for f in files_from_storage(args.path, ignore) }
-		
+
 		for node, (code, result) in six.iteritems(nodes.service.configKeys()):
 			if code != 200:
 				print(u"{0}: {1}".format(node, HTTPStatus(code).human()))
 				self.partial = True
 				continue
-			
+
 			for f in files_from_result(result, ignore):
 				if not f.full_filename in local:
 					continue
-				
+
 				f2 = local[f.full_filename]
 				diff = list(f.diff(f2, node.name, f2.full_filename, node=node))
 				if diff:
@@ -392,7 +396,7 @@ class HSLPushModule(Module):
 
 class HSLModule(Module):
 	'''Manages HSL scripts'''
-	
+
 	submodules = {
 		'dump': HSLDumpModule(),
 		'diff': HSLDiffModule(),


### PR DESCRIPTION
Line 156: `for block in data.split(','):`
Causes `AttributeError: 'NoneType' object has no attribute 'split'`
When using hsl dump if there are any empty config files in the node. This should fix that and make sure no empty files are saved.